### PR TITLE
fix: no content-type header in case of no content HTTP response

### DIFF
--- a/litestar/response/base.py
+++ b/litestar/response/base.py
@@ -91,15 +91,15 @@ class ASGIResponse:
                     "that does not allow content (304, 204, < 200)"
                 )
             body = b""
-
-        encoded_headers.append(
-            (
-                b"content-type",
-                (f"{media_type}; charset={encoding}" if media_type.startswith("text/") else media_type).encode(
-                    "latin-1"
+        else:
+            encoded_headers.append(
+                (
+                    b"content-type",
+                    (f"{media_type}; charset={encoding}" if media_type.startswith("text/") else media_type).encode(
+                        "latin-1"
+                    ),
                 ),
-            ),
-        )
+            )
 
         if content_length is None:
             content_length = len(body)


### PR DESCRIPTION
### Pull Request Checklist
- [x] New code does not change test coverage
- [x] No documentation changes


### Description
This pr makes the content-type header only added in an HTTP response if a content body is present.


### Close Issue(s)
(no issue tracking) Some clients (e.g.: openapi-codegen) are trying to decode empty streams due to the header indicating a content type, while no content is expected.
